### PR TITLE
RISC-V parts for jdk#11188

### DIFF
--- a/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp
@@ -31,6 +31,10 @@
 
 #define __ masm.
 
+int C2SafepointPollStub::size() const {
+  return 20;
+}
+
 void C2SafepointPollStub::emit(C2_MacroAssembler& masm) {
   assert(SharedRuntime::polling_page_return_handler_blob() != NULL,
          "polling page return stub not created yet");
@@ -44,6 +48,10 @@ void C2SafepointPollStub::emit(C2_MacroAssembler& masm) {
   });
   __ sd(t0, Address(xthread, JavaThread::saved_exception_pc_offset()));
   __ far_jump(callback_addr);
+}
+
+int C2EntryBarrierStub::size() const {
+  return 8 * 4 + 4;
 }
 
 void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {

--- a/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp
@@ -51,7 +51,7 @@ void C2SafepointPollStub::emit(C2_MacroAssembler& masm) {
 }
 
 int C2EntryBarrierStub::size() const {
-  return 8 * 4 + 4;
+  return 8 * 4 + 4;  // 4 bytes for alignment margin
 }
 
 void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {


### PR DESCRIPTION
Hi Roman,

Hope this is the right way to PR :-)

After applying [1], my fastdebug build passes, and I am testing a hotspot tier1.
(Before applying [1], there still exists such failure as before. But the calculation-before-emission issue has gone. Thank you for fixing this! We still need the fix [1].)

Best,
Xiaolin

[1] https://github.com/zhengxiaolinX/jdk/commit/0c031a78742d10c84a7cf2f3ec3a823351bb9876