### PR TITLE
8373578: JVMTI replacement for AsyncGetCallTrace

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1004,6 +1004,19 @@
     <Field type="Thread" name="eventThread" label="Thread" />
   </Event>
 
+  <Event name="AsyncStackTrace" category="Java Virtual Machine, Profiling" label="Async Stack Trace"
+    description="Stack trace captured via JVMTI RequestStackTrace extension API"
+    thread="false" experimental="true" startTime="false">
+    <Field type="StackTrace" name="stackTrace" label="Stack Trace" />
+    <Field type="Thread" name="eventThread" label="Thread" />
+    <Field type="long" name="userData" label="User Data"
+      description="User-provided data passed to RequestStackTrace" />
+    <Field type="boolean" name="failed" label="Failed"
+      description="Failed to obtain the stack trace" />
+    <Field type="boolean" name="biased" label="Biased"
+      description="The sample is safepoint-biased" />
+  </Event>
+
   <Event name="ThreadDump" category="Java Virtual Machine, Runtime" label="Thread Dump" period="everyChunk">
     <Field type="string" name="result" label="Thread Dump" />
   </Event>

--- a/src/hotspot/share/prims/jvmtiExtensions.cpp
+++ b/src/hotspot/share/prims/jvmtiExtensions.cpp
@@ -34,6 +34,7 @@
 #include "utilities/macros.hpp"
 
 #if INCLUDE_JFR
+#include "jfr/recorder/jfrRecorder.hpp"
 #include "jfr/recorder/service/jfrOptionSet.hpp"
 #include "jfr/recorder/stacktrace/jfrStackTrace.hpp"
 #include "jfr/recorder/stacktrace/jfrStackTraceRepository.hpp"
@@ -292,17 +293,31 @@ static jvmtiError JNICALL RequestStackTrace(const jvmtiEnv* env, ...) {
     return JVMTI_ERROR_UNSUPPORTED_OPERATION;
   }
 
-  Thread* current = Thread::current();
+  // Use current_or_null_safe() because this is called from a signal handler
+  // and the signal may fire on a thread that is detaching from the VM.
+  Thread* current = Thread::current_or_null_safe();
   if (current == nullptr || !current->is_Java_thread()) {
+    return JVMTI_ERROR_WRONG_PHASE;
+  }
+
+  if (!JfrRecorder::is_created()) {
     return JVMTI_ERROR_WRONG_PHASE;
   }
 
   JavaThread* java_thread = JavaThread::cast(current);
 
+  // Filter out threads that are exiting or excluded, matching the JFR CPU
+  // time sampler's get_java_thread_if_valid() checks.
+  if (java_thread->is_exiting() ||
+      java_thread->is_hidden_from_external_view() ||
+      java_thread->jfr_thread_local()->is_excluded()) {
+    return JVMTI_ERROR_WRONG_PHASE;
+  }
+
   StackWalkRequest request;
   request.set_max_frames(JfrOptionSet::stackdepth());
   request.construct_callback<JfrAsyncStackTraceCallback>(user_data);
-  StackWalker::request_stack_trace(request, java_thread, ucontext, false /* thread_is_suspended */);
+  StackWalker::request_stack_trace(request, java_thread, ucontext, true /* thread_is_suspended */);
 
   return JVMTI_ERROR_NONE;
 #endif // !INCLUDE_JFR

--- a/src/hotspot/share/prims/jvmtiExtensions.cpp
+++ b/src/hotspot/share/prims/jvmtiExtensions.cpp
@@ -28,14 +28,31 @@
 #include "prims/jvmtiThreadState.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/javaThread.hpp"
 #include "runtime/jniHandles.inline.hpp"
 #include "runtime/mountUnmountDisabler.hpp"
+#include "utilities/macros.hpp"
+
+#if INCLUDE_JFR
+#include "jfr/recorder/service/jfrOptionSet.hpp"
+#include "jfr/recorder/stacktrace/jfrStackTrace.hpp"
+#include "jfr/recorder/stacktrace/jfrStackTraceRepository.hpp"
+#include "jfr/support/jfrThreadLocal.hpp"
+#include "jfr/utilities/jfrTypes.hpp"
+#include "jfrfiles/jfrEventClasses.hpp"
+#endif
+
+#if INCLUDE_STACKWALKER
+#include "runtime/stackWalker.hpp"
+#endif
 
 // the list of extension functions
 GrowableArray<jvmtiExtensionFunctionInfo*>* JvmtiExtensions::_ext_functions;
 
 // the list of extension events
 GrowableArray<jvmtiExtensionEventInfo*>* JvmtiExtensions::_ext_events;
+
+volatile bool JvmtiExtensions::_request_stack_trace_requested = false;
 
 
 //
@@ -167,6 +184,130 @@ static jvmtiError JNICALL GetCarrierThread(const jvmtiEnv* env, ...) {
   return JVMTI_ERROR_NONE;
 }
 
+#if INCLUDE_JFR
+
+class JfrAsyncStackTraceCallback : public StackWalkerCallback {
+  JavaThread* _requested_thread;
+  JfrTicks _sample_ticks;
+  JfrStackTrace* _stack_trace;
+  traceid _tid;
+  jlong _user_data;
+  bool _biased;
+
+  static u1 convert_type(StackWalkerFrameType type) {
+    switch (type) {
+      case StackWalkerFrameType::FRAME_INTERPRETER: return JfrStackFrame::FRAME_INTERPRETER;
+      case StackWalkerFrameType::FRAME_JIT:         return JfrStackFrame::FRAME_JIT;
+      case StackWalkerFrameType::FRAME_INLINE:      return JfrStackFrame::FRAME_INLINE;
+      case StackWalkerFrameType::FRAME_NATIVE:      return JfrStackFrame::FRAME_NATIVE;
+    }
+    ShouldNotReachHere();
+  }
+
+public:
+  JfrAsyncStackTraceCallback(jlong user_data) :
+    _requested_thread(nullptr),
+    _sample_ticks(JfrTicks::now()),
+    _stack_trace(nullptr),
+    _tid(0),
+    _user_data(user_data),
+    _biased(false) {
+  }
+
+  ~JfrAsyncStackTraceCallback() {
+    if (_stack_trace != nullptr) {
+      delete _stack_trace;
+    }
+  }
+
+  void begin_stacktrace(JavaThread* jt, bool continuation, bool biased) final {
+    assert(_stack_trace == nullptr, "invariant");
+    _requested_thread = jt;
+    _stack_trace = new JfrStackTrace;
+    _stack_trace->start_record_frames();
+    _biased = biased;
+    JfrThreadLocal* tl = jt->jfr_thread_local();
+    _tid = continuation ? tl->vthread_id_with_epoch_update(jt) : JfrThreadLocal::jvm_thread_id(jt);
+  }
+
+  void end_stacktrace(bool truncated) final {
+    assert(_stack_trace != nullptr, "invariant");
+    _stack_trace->end_record_frames(truncated);
+    traceid sid = JfrStackTraceRepository::add(*_stack_trace);
+    assert(sid != 0, "invariant");
+
+    EventAsyncStackTrace event(UNTIMED);
+    event.set_starttime(_sample_ticks);
+    event.set_eventThread(_tid);
+    event.set_stackTrace(sid);
+    event.set_userData(_user_data);
+    event.set_failed(false);
+    event.set_biased(_biased);
+    event.commit();
+  }
+
+  void stack_frame(const Method* method, int bci, int line_no, StackWalkerFrameType type) final {
+    assert(_stack_trace != nullptr, "invariant");
+    _stack_trace->record_frame(method, bci, line_no, convert_type(type));
+  }
+
+  void failure() final {
+    EventAsyncStackTrace event(UNTIMED);
+    event.set_starttime(_sample_ticks);
+    event.set_eventThread(_tid);
+    event.set_stackTrace(0);
+    event.set_userData(_user_data);
+    event.set_failed(true);
+    event.set_biased(false);
+    event.commit();
+  }
+};
+
+#endif // INCLUDE_JFR
+
+// Parameters: (const jvmtiEnv* env)
+static jvmtiError JNICALL InitializeRequestStackTrace(const jvmtiEnv* env, ...) {
+  JvmtiExtensions::set_request_stack_trace_requested();
+  return JVMTI_ERROR_NONE;
+}
+
+// Parameters: (const jvmtiEnv* env, jthread thread, void* ucontext, jlong user_data)
+static jvmtiError JNICALL RequestStackTrace(const jvmtiEnv* env, ...) {
+#if !INCLUDE_JFR
+  return JVMTI_ERROR_NOT_AVAILABLE;
+#else
+  jthread thread = nullptr;
+  void* ucontext = nullptr;
+  jlong user_data = 0;
+  va_list ap;
+
+  va_start(ap, env);
+  thread = va_arg(ap, jthread);
+  ucontext = va_arg(ap, void*);
+  user_data = va_arg(ap, jlong);
+  va_end(ap);
+
+  // Only sampling the current thread is supported (thread must be null).
+  if (thread != nullptr) {
+    return JVMTI_ERROR_UNSUPPORTED_OPERATION;
+  }
+
+  Thread* current = Thread::current();
+  if (current == nullptr || !current->is_Java_thread()) {
+    return JVMTI_ERROR_WRONG_PHASE;
+  }
+
+  JavaThread* java_thread = JavaThread::cast(current);
+
+  StackWalkRequest request;
+  request.set_max_frames(JfrOptionSet::stackdepth());
+  request.construct_callback<JfrAsyncStackTraceCallback>(user_data);
+  StackWalker::request_stack_trace(request, java_thread, ucontext, false /* thread_is_suspended */);
+
+  return JVMTI_ERROR_NONE;
+#endif // !INCLUDE_JFR
+}
+
 // register extension functions and events. In this implementation we
 // have a single extension function (to prove the API) that tests if class
 // unloading is enabled or disabled. We also have a single extension event
@@ -225,9 +366,43 @@ void JvmtiExtensions::register_extensions() {
     errors
   };
 
+  static jvmtiExtensionFunctionInfo ext_func_init_rst = {
+    (jvmtiExtensionFunction)InitializeRequestStackTrace,
+    (char*)"com.sun.hotspot.functions.InitializeRequestStackTrace",
+    (char*)"Initialize the RequestStackTrace extension (must be called during Agent_OnLoad)",
+    0,
+    nullptr,
+    0,
+    nullptr
+  };
+
+  static jvmtiParamInfo func_params_rst[] = {
+    { (char*)"thread",    JVMTI_KIND_IN, JVMTI_TYPE_JTHREAD, JNI_TRUE },
+    { (char*)"ucontext",  JVMTI_KIND_IN_PTR, JVMTI_TYPE_CVOID, JNI_TRUE },
+    { (char*)"user_data", JVMTI_KIND_IN, JVMTI_TYPE_JLONG, JNI_FALSE }
+  };
+
+  static jvmtiError rst_errors[] = {
+    JVMTI_ERROR_NOT_AVAILABLE,
+    JVMTI_ERROR_UNSUPPORTED_OPERATION,
+    JVMTI_ERROR_WRONG_PHASE
+  };
+
+  static jvmtiExtensionFunctionInfo ext_func_rst = {
+    (jvmtiExtensionFunction)RequestStackTrace,
+    (char*)"com.sun.hotspot.functions.RequestStackTrace",
+    (char*)"Request an async stack trace of the current thread, emitted as a JFR AsyncStackTrace event",
+    sizeof(func_params_rst)/sizeof(func_params_rst[0]),
+    func_params_rst,
+    sizeof(rst_errors)/sizeof(jvmtiError),
+    rst_errors
+  };
+
   _ext_functions->append(&ext_func0);
   _ext_functions->append(&ext_func1);
   _ext_functions->append(&ext_func2);
+  _ext_functions->append(&ext_func_init_rst);
+  _ext_functions->append(&ext_func_rst);
 
   // register our extension event
 
@@ -458,4 +633,12 @@ jvmtiError JvmtiExtensions::set_event_callback(JvmtiEnv* env,
                                                      callback);
 
   return JVMTI_ERROR_NONE;
+}
+
+void JvmtiExtensions::post_initialize() {
+#if INCLUDE_STACKWALKER
+  if (_request_stack_trace_requested) {
+    StackWalker::initialize();
+  }
+#endif
 }

--- a/src/hotspot/share/prims/jvmtiExtensions.hpp
+++ b/src/hotspot/share/prims/jvmtiExtensions.hpp
@@ -40,10 +40,18 @@ class JvmtiExtensions : public AllStatic {
  private:
   static GrowableArray<jvmtiExtensionFunctionInfo*>* _ext_functions;
   static GrowableArray<jvmtiExtensionEventInfo*>* _ext_events;
+  static volatile bool _request_stack_trace_requested;
 
  public:
   // register extensions function
   static void register_extensions();
+
+  // called after VM initialization to perform deferred setup
+  static void post_initialize();
+
+  // track whether InitializeRequestStackTrace was called
+  static void set_request_stack_trace_requested() { _request_stack_trace_requested = true; }
+  static bool is_request_stack_trace_requested()  { return _request_stack_trace_requested; }
 
   // returns the list of extension functions
   static jvmtiError get_functions(JvmtiEnv* env, jint* extension_count_ptr,

--- a/src/hotspot/share/runtime/init.cpp
+++ b/src/hotspot/share/runtime/init.cpp
@@ -205,6 +205,8 @@ jint init_globals2() {
   final_stubs_init();    // final StubRoutines stubs
   MethodHandles::generate_adapters();
 
+  JvmtiExtensions::post_initialize();
+
   // All the flags that get adjusted by VM_Version_init and os::init_2
   // have been set so dump the flags now.
   if (PrintFlagsFinal || PrintFlagsRanges) {

--- a/src/hotspot/share/runtime/init.cpp
+++ b/src/hotspot/share/runtime/init.cpp
@@ -205,7 +205,9 @@ jint init_globals2() {
   final_stubs_init();    // final StubRoutines stubs
   MethodHandles::generate_adapters();
 
+#if INCLUDE_JVMTI
   JvmtiExtensions::post_initialize();
+#endif
 
   // All the flags that get adjusted by VM_Version_init and os::init_2
   // have been set so dump the flags now.

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -73,6 +73,7 @@
 #include "runtime/javaThread.hpp"
 #include "runtime/os.hpp"
 #include "runtime/sharedRuntime.hpp"
+#include "runtime/stackWalker.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "runtime/task.hpp"
 #include "runtime/threads.hpp"
@@ -512,6 +513,7 @@ void before_exit(JavaThread* thread, bool halt) {
   #endif
 
   print_statistics();
+  STACKWALKER_ONLY(StackWalker::print_statistics();)
 
   { MutexLocker ml(BeforeExit_lock);
     _before_exit_status = BEFORE_EXIT_DONE;

--- a/src/hotspot/share/runtime/safepointMechanism.inline.hpp
+++ b/src/hotspot/share/runtime/safepointMechanism.inline.hpp
@@ -31,6 +31,9 @@
 #include "runtime/handshake.hpp"
 #include "runtime/safepoint.hpp"
 #include "runtime/stackWatermarkSet.hpp"
+#if INCLUDE_STACKWALKER
+#include "runtime/stackWalker.hpp"
+#endif
 
 // Caller is responsible for using a memory barrier if needed.
 inline void SafepointMechanism::ThreadData::set_polling_page(uintptr_t poll_value) {
@@ -57,7 +60,8 @@ bool SafepointMechanism::global_poll() {
 }
 
 inline bool SafepointMechanism::has_pending_safepoint(JavaThread* thread) {
-  return global_poll() || thread->handshake_state()->has_operation();
+  return global_poll() || thread->handshake_state()->has_operation()
+         STACKWALKER_ONLY(|| thread->stackwalker_thread_local().has_requests());
 }
 
 bool SafepointMechanism::should_process(JavaThread* thread, bool allow_suspend) {

--- a/src/hotspot/share/runtime/stackWalker.cpp
+++ b/src/hotspot/share/runtime/stackWalker.cpp
@@ -520,9 +520,11 @@ static bool in_stack(intptr_t* ptr, const JavaThread* jt) {
   return jt->is_in_full_stack_checked(reinterpret_cast<address>(ptr));
 }
 
+#ifdef ASSERT
 static bool sp_in_stack(const StackWalkRequest& request, const JavaThread* jt) {
   return in_stack(static_cast<intptr_t*>(request.sample_sp()), jt);
 }
+#endif
 
 static bool fp_in_stack(const StackWalkRequest& request, const JavaThread* jt) {
   return in_stack(static_cast<intptr_t*>(request.sample_bcp()), jt);

--- a/src/hotspot/share/runtime/stackWalker.cpp
+++ b/src/hotspot/share/runtime/stackWalker.cpp
@@ -27,7 +27,6 @@
 
 #if INCLUDE_STACKWALKER
 
-#include "memory/allocation.hpp"
 #include "code/codeCache.hpp"
 #include "code/debugInfoRec.hpp"
 #include "gc/shared/gc_globals.hpp"

--- a/src/hotspot/share/runtime/stackWalker.cpp
+++ b/src/hotspot/share/runtime/stackWalker.cpp
@@ -28,6 +28,7 @@
 #if INCLUDE_STACKWALKER
 
 #include "gc/shared/gc_globals.hpp"
+#include "logging/log.hpp"
 #include "memory/allocation.hpp"
 #include "code/codeCache.hpp"
 #include "code/debugInfoRec.hpp"
@@ -45,6 +46,34 @@
 #include "utilities/spinYield.hpp"
 
 volatile u4 StackWalkerRequestQueue::_lost_requests_sum = 0;
+
+// ---- Bias reason counters ----
+// request_stack_trace outcomes
+static volatile u4 requests_total = 0;
+static volatile u4 requests_not_suspended = 0;
+
+// build_stack_walk_request outcomes
+static volatile u4 requests_unbiased_ljf = 0;
+static volatile u4 requests_unbiased_ctx = 0;
+static volatile u4 requests_biased = 0;
+
+// build_from_ljf failure reasons
+static volatile u4 ljf_no_java_sp = 0;
+static volatile u4 ljf_null_pc = 0;
+static volatile u4 ljf_critical_section = 0;
+static volatile u4 ljf_build_failed = 0;
+
+// build_from_context failure reasons
+static volatile u4 ctx_no_context = 0;
+static volatile u4 ctx_critical_section = 0;
+static volatile u4 ctx_sender_failed = 0;
+static volatile u4 ctx_build_failed = 0;
+
+// compute_top_frame walk-time bias
+static volatile u4 walk_no_last_java_frame = 0;
+static volatile u4 walk_null_pc_or_no_blob = 0;
+static volatile u4 walk_safepoint_bias = 0;
+static volatile u4 walk_safepoint_corrected = 0;
 
 class StackWalkerVframeStream : public vframeStreamCommon {
   bool _vthread;
@@ -607,6 +636,7 @@ static bool build_from_ljf(StackWalkRequest& request,
   if (last_pc == nullptr) {
     last_pc = frame::return_address(static_cast<intptr_t*>(request.sample_sp()));
     if (last_pc == nullptr) {
+      AtomicAccess::inc(&ljf_null_pc);
       return false;
     }
   }
@@ -614,14 +644,23 @@ static bool build_from_ljf(StackWalkRequest& request,
   if (is_interpreter(last_pc)) {
     const StackWalkerThreadLocal& tl = jt->stackwalker_thread_local();
     if (tl.in_critical_section()) {
+      AtomicAccess::inc(&ljf_critical_section);
       return false;
     }
     request.set_sample_pc(last_pc);
     request.set_sample_bcp(jt->frame_anchor()->last_Java_fp());
-    return build_for_interpreter(request, jt);
+    bool result = build_for_interpreter(request, jt);
+    if (!result) {
+      AtomicAccess::inc(&ljf_build_failed);
+    }
+    return result;
   }
   request.set_sample_pc(last_pc);
-  return build(request, nullptr, jt);
+  bool result = build(request, nullptr, jt);
+  if (!result) {
+    AtomicAccess::inc(&ljf_build_failed);
+  }
+  return result;
 }
 
 static bool build_from_context(StackWalkRequest& request,
@@ -637,6 +676,7 @@ static bool build_from_context(StackWalkRequest& request,
   if (is_interpreter(request)) {
     const StackWalkerThreadLocal& tl = jt->stackwalker_thread_local();
     if (tl.in_critical_section() || !in_stack(fp, jt)) {
+      AtomicAccess::inc(&ctx_critical_section);
       return false;
     }
     if (frame::is_interpreter_frame_setup_at(fp, request.sample_sp())) {
@@ -650,10 +690,15 @@ static bool build_from_context(StackWalkRequest& request,
     request.set_sample_bcp(fp);
     fp = sender_for_interpreter_frame(request, jt);
     if (request.sample_pc() == nullptr || request.sample_sp() == nullptr) {
+      AtomicAccess::inc(&ctx_sender_failed);
       return false;
     }
   }
-  return build(request, fp, jt);
+  bool result = build(request, fp, jt);
+  if (!result) {
+    AtomicAccess::inc(&ctx_build_failed);
+  }
+  return result;
 }
 
 // A biased stack-walk request is denoted by an empty bcp and an empty pc.
@@ -673,13 +718,26 @@ void StackWalker::build_stack_walk_request(StackWalkRequest& request, const void
 
   // Prioritize the ljf, if one exists.
   request.set_sample_sp(java_thread->last_Java_sp());
-  if (request.sample_sp() != nullptr && build_from_ljf(request, java_thread)) {
-    set_unbiased(request, java_thread);
-  } else if (ucontext != nullptr && build_from_context(request, ucontext, java_thread)) {
-    set_unbiased(request, java_thread);
+  if (request.sample_sp() != nullptr) {
+    if (build_from_ljf(request, java_thread)) {
+      AtomicAccess::inc(&requests_unbiased_ljf);
+      set_unbiased(request, java_thread);
+      return;
+    }
   } else {
-    set_biased(request, java_thread);
+    AtomicAccess::inc(&ljf_no_java_sp);
   }
+  if (ucontext != nullptr) {
+    if (build_from_context(request, ucontext, java_thread)) {
+      AtomicAccess::inc(&requests_unbiased_ctx);
+      set_unbiased(request, java_thread);
+      return;
+    }
+  } else {
+    AtomicAccess::inc(&ctx_no_context);
+  }
+  AtomicAccess::inc(&requests_biased);
+  set_biased(request, java_thread);
 }
 
 static bool check_state(const JavaThread* thread) {
@@ -693,6 +751,8 @@ static bool check_state(const JavaThread* thread) {
 }
 
 void StackWalker::request_stack_trace(StackWalkRequest& request, JavaThread* jt, const void* context, bool thread_is_suspended) {
+  AtomicAccess::inc(&requests_total);
+
   StackWalkerThreadLocal& tl = jt->stackwalker_thread_local();
   StackWalkerRequestQueue& queue = tl.queue();
   if (thread_is_suspended && !check_state(jt)) {
@@ -712,6 +772,8 @@ void StackWalker::request_stack_trace(StackWalkRequest& request, JavaThread* jt,
     // For foreign threads, assume biased stack-walking and don't even attempt
     // to build an unbiased request.
     build_stack_walk_request(request, context, jt);
+  } else {
+    AtomicAccess::inc(&requests_not_suspended);
   }
 
   if (queue.enqueue(request)) {
@@ -830,6 +892,7 @@ static bool compute_top_frame(StackWalkRequest& request, frame& top_frame, bool&
   assert(jt != nullptr, "invariant");
 
   if (!jt->has_last_Java_frame()) {
+    AtomicAccess::inc(&walk_no_last_java_frame);
     return false;
   }
 
@@ -841,6 +904,7 @@ static bool compute_top_frame(StackWalkRequest& request, frame& top_frame, bool&
   CodeBlob* sampled_cb;
   if (sampled_pc == nullptr || (sampled_cb = CodeCache::find_blob(sampled_pc)) == nullptr) {
     // A biased sample is requested or no code blob.
+    AtomicAccess::inc(&walk_null_pc_or_no_blob);
     top_frame = jt->last_frame();
     in_continuation = is_in_continuation(top_frame, jt);
     biased = true;
@@ -894,6 +958,7 @@ static bool compute_top_frame(StackWalkRequest& request, frame& top_frame, bool&
 
   assert(!stream.current()->is_safepoint_blob_frame(), "invariant");
 
+  AtomicAccess::inc(&walk_safepoint_bias);
   biased = true;
 
   // Search the first frame that is above the sampled sp.
@@ -919,6 +984,7 @@ static bool compute_top_frame(StackWalkRequest& request, frame& top_frame, bool&
         const PcDesc* const pc_desc = get_pc_desc(sampled_nm, sampled_pc);
         if (is_valid(pc_desc)) {
           current->adjust_pc(pc_desc->real_pc(sampled_nm));
+          AtomicAccess::inc(&walk_safepoint_corrected);
           biased = false;
         }
       }
@@ -1136,6 +1202,47 @@ void StackWalker::on_javathread_create(JavaThread* thread) {
     return;
   }
   thread->stackwalker_thread_local().queue().init();
+}
+
+void StackWalker::print_statistics() {
+  u4 total = AtomicAccess::load(&requests_total);
+  if (total == 0) {
+    return;
+  }
+
+#define SW_LOG_COUNTER(name) \
+  log_info(stackwalk)("  %-30s %10u (%5.1f%%)", #name, AtomicAccess::load(&name), 100.0 * AtomicAccess::load(&name) / total)
+
+  log_info(stackwalk)("StackWalker bias statistics:");
+  log_info(stackwalk)("  %-30s %10u", "requests_total", total);
+
+  log_info(stackwalk)("  -- request_stack_trace outcomes --");
+  SW_LOG_COUNTER(requests_not_suspended);
+
+  log_info(stackwalk)("  -- build_stack_walk_request outcomes --");
+  SW_LOG_COUNTER(requests_unbiased_ljf);
+  SW_LOG_COUNTER(requests_unbiased_ctx);
+  SW_LOG_COUNTER(requests_biased);
+
+  log_info(stackwalk)("  -- build_from_ljf failure reasons --");
+  SW_LOG_COUNTER(ljf_no_java_sp);
+  SW_LOG_COUNTER(ljf_null_pc);
+  SW_LOG_COUNTER(ljf_critical_section);
+  SW_LOG_COUNTER(ljf_build_failed);
+
+  log_info(stackwalk)("  -- build_from_context failure reasons --");
+  SW_LOG_COUNTER(ctx_no_context);
+  SW_LOG_COUNTER(ctx_critical_section);
+  SW_LOG_COUNTER(ctx_sender_failed);
+  SW_LOG_COUNTER(ctx_build_failed);
+
+  log_info(stackwalk)("  -- compute_top_frame walk-time bias --");
+  SW_LOG_COUNTER(walk_no_last_java_frame);
+  SW_LOG_COUNTER(walk_null_pc_or_no_blob);
+  SW_LOG_COUNTER(walk_safepoint_bias);
+  SW_LOG_COUNTER(walk_safepoint_corrected);
+
+#undef SW_LOG_COUNTER
 }
 
 #endif // INCLUDE_STACKWALKER

--- a/src/hotspot/share/runtime/stackWalker.hpp
+++ b/src/hotspot/share/runtime/stackWalker.hpp
@@ -281,6 +281,8 @@ public:
   // Entry point for the runtime to trigger stack-walk processing.
   static inline void check_and_process_requests(JavaThread* jt);
 
+  static void print_statistics();
+
   DEBUG_ONLY(static bool set_out_of_stack_walking_enabled(bool enabled);)
 };
 

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -241,6 +241,11 @@
       <setting name="enabled" control="method-sampling-enabled">true</setting>
     </event>
 
+    <event name="jdk.AsyncStackTrace">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
     <event name="jdk.SafepointBegin">
       <setting name="enabled">true</setting>
       <setting name="threshold">10 ms</setting>

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -221,6 +221,11 @@
       <setting name="enabled">true</setting>
     </event>
 
+    <event name="jdk.AsyncStackTrace">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
     <event name="jdk.MethodTrace">
       <setting name="enabled">true</setting>
       <setting name="filter" control="method-trace"></setting>


### PR DESCRIPTION
WIP, based on PR #29844, showing a JVMTI-with-JFR implementation, that reports the requested stack-trace via a new AsyncStackTrace JFR event.